### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/mquinnv/warpclip/security/code-scanning/1](https://github.com/mquinnv/warpclip/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block to the `test` job. Since the `test` job only needs to read the repository contents (e.g., to check out code), we will set `contents: read` as the permission. This change ensures that the job does not have unnecessary write access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
